### PR TITLE
fix: correct bug when attempting to infer schema on delete messages only

### DIFF
--- a/sources/pg_legacy_replication/helpers.py
+++ b/sources/pg_legacy_replication/helpers.py
@@ -506,7 +506,7 @@ def infer_table_schema(
         )
         for i, col in enumerate(tuples)
         if (col_name := _actual_column_name(col))
-           and (not included_columns or col_name in included_columns)
+        and (not included_columns or col_name in included_columns)
     }
 
     # Add replication columns

--- a/sources/pg_legacy_replication/helpers.py
+++ b/sources/pg_legacy_replication/helpers.py
@@ -601,19 +601,18 @@ def compare_schemas(last: TTableSchema, new: TTableSchema) -> TTableSchema:
     precise one if they are relatively equal or else raises a
     AssertionError due to an incompatible schema change
     """
-    table_name = last["name"]
-    assert table_name == new["name"], "Table names do not match"
+    assert last["name"] == new["name"], "Table names do not match"
 
-    table_schema = TTableSchema(name=table_name, columns={})
+    table_schema = TTableSchema(name=last["name"], columns={})
     last_cols, new_cols = last["columns"], new["columns"]
     assert len(last_cols) == len(
         new_cols
-    ), f"Columns mismatch last:{last['columns']} new:{new['columns']}"
+    ), f"Columns mismatch last:{last_cols} new:{new_cols}"
 
     for name, s1 in last_cols.items():
         s2 = new_cols.get(name)
         assert (
-            s2 is not None and s1["data_type"] == s2["data_type"]
+            s2 and s1["data_type"] == s2["data_type"]
         ), f"Incompatible schema for column '{name}'"
 
         # Ensure new has no fields outside allowed fields

--- a/sources/pg_legacy_replication/helpers.py
+++ b/sources/pg_legacy_replication/helpers.py
@@ -506,7 +506,7 @@ def infer_table_schema(
         )
         for i, col in enumerate(tuples)
         if (col_name := _actual_column_name(col))
-        and (not included_columns or col_name in included_columns)
+           and (not included_columns or col_name in included_columns)
     }
 
     # Add replication columns
@@ -623,7 +623,13 @@ def compare_schemas(last: TTableSchema, new: TTableSchema) -> TTableSchema:
         # Select the more precise schema by comparing nullable, precision, and scale
         col_schema = TColumnSchema(name=name, data_type=s1["data_type"])
         if "nullable" in s1 or "nullable" in s2:
-            col_schema["nullable"] = s1.get("nullable", s2.get("nullable"))
+            # Get nullable values (could be True, False, or None)
+            s1_null = s1.get("nullable")
+            s2_null = s2.get("nullable")
+            if s1_null is not None and s2_null is not None:
+                col_schema["nullable"] = s1_null or s2_null  # Default is True
+            else:
+                col_schema["nullable"] = s1_null if s1_null is not None else s2_null
         if "precision" in s1 or "precision" in s2:
             col_schema["precision"] = s1.get("precision", s2.get("precision"))
         if "scale" in s1 or "scale" in s2:

--- a/sources/pg_legacy_replication/helpers.py
+++ b/sources/pg_legacy_replication/helpers.py
@@ -569,7 +569,7 @@ def gen_data_item(
         col_name = _actual_column_name(data)
         if not included_columns or col_name in included_columns:
             data_item[col_name] = _to_dlt_val(
-                data, column_schema[col_name]["data_type"], for_delete=is_delete
+                data, column_schema[col_name], for_delete=is_delete
             )
 
     return data_item

--- a/sources/pg_legacy_replication/schema_types.py
+++ b/sources/pg_legacy_replication/schema_types.py
@@ -143,10 +143,6 @@ def _to_dlt_column_schema(
     # Set nullable attribute if type_info is available
     if type_info:
         column_schema["nullable"] = type_info.value_optional
-    # If the type_info is None then it must be a DELETE message, so any fields
-    # which are present should be NOT NULL (i.e. primary key fields)
-    elif (attr := _get_datum_attr(datum)) and getattr(datum, attr) is not None:
-        column_schema["nullable"] = False
 
     return column_schema
 

--- a/tests/pg_legacy_replication/cases.py
+++ b/tests/pg_legacy_replication/cases.py
@@ -434,12 +434,7 @@ TABLE_SCHEMAS: List[TTableSchema] = [
     {
         "name": "tbl_x",
         "columns": {
-            "id_x": {
-                "data_type": "bigint",
-                "name": "id_x",
-                "precision": 64,
-                "nullable": False,
-            },
+            "id_x": {"data_type": "bigint", "name": "id_x", "precision": 64},
             "val_x": {"data_type": "text", "name": "val_x"},
             "col_bool": {"data_type": "bool", "name": "col_bool"},
             "col_bytea": {"data_type": "binary", "name": "col_bytea"},

--- a/tests/pg_legacy_replication/cases.py
+++ b/tests/pg_legacy_replication/cases.py
@@ -1,5 +1,6 @@
 from base64 import b64encode
-from typing import List
+from enum import IntEnum
+from typing import List, Tuple
 
 import pendulum
 from dlt.common import Decimal
@@ -497,4 +498,509 @@ TABLE_SCHEMAS: List[TTableSchema] = [
             },
         },
     },
+]
+
+
+class SchemaChoice(IntEnum):
+    first = 0
+    second = 1
+    error = -1
+
+
+SIMILAR_SCHEMAS: List[Tuple[TTableSchema, TTableSchema, SchemaChoice]] = [
+    (
+        {
+            "name": "items",
+            "columns": {
+                "col1": {
+                    "name": "col1",
+                    "data_type": "bigint",
+                    "precision": 64,
+                    "nullable": False,
+                },
+                "col2": {"name": "col2", "data_type": "double", "nullable": False},
+                "col3": {"name": "col3", "data_type": "bool", "nullable": False},
+                "col4": {"name": "col4", "data_type": "timestamp", "nullable": False},
+                "col5": {"name": "col5", "data_type": "text", "nullable": False},
+                "col6": {
+                    "name": "col6",
+                    "data_type": "decimal",
+                    "precision": 38,
+                    "scale": 9,
+                    "nullable": False,
+                },
+                "col7": {"name": "col7", "data_type": "binary", "nullable": False},
+                "col9": {"name": "col9", "data_type": "json", "nullable": False},
+                "col10": {"name": "col10", "data_type": "date", "nullable": False},
+                "col11": {"name": "col11", "data_type": "time", "nullable": False},
+                "col1_null": {
+                    "name": "col1_null",
+                    "data_type": "bigint",
+                    "precision": 64,
+                    "nullable": True,
+                },
+                "col2_null": {
+                    "name": "col2_null",
+                    "data_type": "double",
+                    "nullable": True,
+                },
+                "col3_null": {
+                    "name": "col3_null",
+                    "data_type": "bool",
+                    "nullable": True,
+                },
+                "col4_null": {
+                    "name": "col4_null",
+                    "data_type": "timestamp",
+                    "nullable": True,
+                },
+                "col5_null": {
+                    "name": "col5_null",
+                    "data_type": "text",
+                    "nullable": True,
+                },
+                "col6_null": {
+                    "name": "col6_null",
+                    "data_type": "decimal",
+                    "precision": 38,
+                    "scale": 9,
+                    "nullable": True,
+                },
+                "col7_null": {
+                    "name": "col7_null",
+                    "data_type": "binary",
+                    "nullable": True,
+                },
+                "col9_null": {
+                    "name": "col9_null",
+                    "data_type": "json",
+                    "nullable": True,
+                },
+                "col10_null": {
+                    "name": "col10_null",
+                    "data_type": "date",
+                    "nullable": True,
+                },
+                "col11_null": {
+                    "name": "col11_null",
+                    "data_type": "time",
+                    "nullable": True,
+                },
+                "col1_precision": {
+                    "name": "col1_precision",
+                    "data_type": "bigint",
+                    "precision": 16,
+                    "nullable": False,
+                },
+                "col4_precision": {
+                    "name": "col4_precision",
+                    "data_type": "timestamp",
+                    "precision": 3,
+                    "nullable": False,
+                },
+                "col5_precision": {
+                    "name": "col5_precision",
+                    "data_type": "text",
+                    "precision": 25,
+                    "nullable": False,
+                },
+                "col6_precision": {
+                    "name": "col6_precision",
+                    "data_type": "decimal",
+                    "precision": 6,
+                    "scale": 2,
+                    "nullable": False,
+                },
+                "col7_precision": {
+                    "name": "col7_precision",
+                    "data_type": "binary",
+                    "nullable": False,
+                },
+                "col11_precision": {
+                    "name": "col11_precision",
+                    "data_type": "time",
+                    "precision": 3,
+                    "nullable": False,
+                },
+                "_dlt_load_id": {
+                    "name": "_dlt_load_id",
+                    "data_type": "text",
+                    "nullable": False,
+                },
+                "_dlt_id": {"name": "_dlt_id", "data_type": "text", "nullable": False},
+                "_pg_lsn": {"data_type": "bigint", "name": "_pg_lsn", "nullable": True},
+                "_pg_deleted_ts": {
+                    "data_type": "timestamp",
+                    "name": "_pg_deleted_ts",
+                    "nullable": True,
+                },
+            },
+        },
+        {
+            "name": "items",
+            "columns": {
+                "col1": {
+                    "name": "col1",
+                    "data_type": "bigint",
+                    "precision": 64,
+                    "nullable": False,
+                },
+                "col2": {"name": "col2", "data_type": "double"},
+                "col3": {"name": "col3", "data_type": "bool"},
+                "col4": {"name": "col4", "data_type": "timestamp"},
+                "col5": {"name": "col5", "data_type": "text"},
+                "col6": {"name": "col6", "data_type": "decimal"},
+                "col7": {"name": "col7", "data_type": "binary"},
+                "col9": {"name": "col9", "data_type": "json"},
+                "col10": {"name": "col10", "data_type": "date"},
+                "col11": {"name": "col11", "data_type": "time"},
+                "col1_null": {
+                    "name": "col1_null",
+                    "data_type": "bigint",
+                    "precision": 64,
+                },
+                "col2_null": {"name": "col2_null", "data_type": "double"},
+                "col3_null": {"name": "col3_null", "data_type": "bool"},
+                "col4_null": {"name": "col4_null", "data_type": "timestamp"},
+                "col5_null": {"name": "col5_null", "data_type": "text"},
+                "col6_null": {"name": "col6_null", "data_type": "decimal"},
+                "col7_null": {"name": "col7_null", "data_type": "binary"},
+                "col9_null": {"name": "col9_null", "data_type": "json"},
+                "col10_null": {"name": "col10_null", "data_type": "date"},
+                "col11_null": {"name": "col11_null", "data_type": "time"},
+                "col1_precision": {
+                    "name": "col1_precision",
+                    "data_type": "bigint",
+                    "precision": 16,
+                },
+                "col4_precision": {"name": "col4_precision", "data_type": "timestamp"},
+                "col5_precision": {"name": "col5_precision", "data_type": "text"},
+                "col6_precision": {"name": "col6_precision", "data_type": "decimal"},
+                "col7_precision": {"name": "col7_precision", "data_type": "binary"},
+                "col11_precision": {"name": "col11_precision", "data_type": "time"},
+                "_dlt_load_id": {"name": "_dlt_load_id", "data_type": "text"},
+                "_dlt_id": {"name": "_dlt_id", "data_type": "text"},
+                "_pg_lsn": {"data_type": "bigint", "name": "_pg_lsn", "nullable": True},
+                "_pg_deleted_ts": {
+                    "data_type": "timestamp",
+                    "name": "_pg_deleted_ts",
+                    "nullable": True,
+                },
+            },
+        },
+        SchemaChoice.first,
+    ),
+    (
+        {
+            "name": "items",
+            "columns": {
+                "_dlt_id": {"data_type": "text", "name": "_dlt_id", "nullable": False},
+                "_dlt_load_id": {
+                    "data_type": "text",
+                    "name": "_dlt_load_id",
+                    "nullable": False,
+                },
+                "c1": {
+                    "data_type": "bigint",
+                    "name": "c1",
+                    "nullable": True,
+                    "precision": 64,
+                },
+                "c2": {
+                    "data_type": "bigint",
+                    "name": "c2",
+                    "nullable": True,
+                    "precision": 64,
+                },
+                "c3": {
+                    "data_type": "bigint",
+                    "name": "c3",
+                    "nullable": True,
+                    "precision": 64,
+                },
+                "_pg_deleted_ts": {
+                    "data_type": "timestamp",
+                    "name": "_pg_deleted_ts",
+                    "nullable": True,
+                },
+                "_pg_lsn": {"data_type": "bigint", "name": "_pg_lsn", "nullable": True},
+            },
+        },
+        {
+            "name": "items",
+            "columns": {
+                "_dlt_id": {"data_type": "text", "name": "_dlt_id", "nullable": False},
+                "_dlt_load_id": {
+                    "data_type": "text",
+                    "name": "_dlt_load_id",
+                    "nullable": False,
+                },
+                "c1": {
+                    "data_type": "bigint",
+                    "name": "c1",
+                    "nullable": True,
+                    "precision": 64,
+                },
+                "c2": {
+                    "data_type": "bigint",
+                    "name": "c2",
+                    "nullable": True,
+                    "precision": 64,
+                },
+                "c3": {
+                    "data_type": "bigint",
+                    "name": "c3",
+                    "nullable": True,
+                    "precision": 64,
+                },
+                # Added c4 column
+                "c4": {
+                    "data_type": "bigint",
+                    "name": "c4",
+                    "nullable": True,
+                    "precision": 64,
+                },
+                "_pg_deleted_ts": {
+                    "data_type": "timestamp",
+                    "name": "_pg_deleted_ts",
+                    "nullable": True,
+                },
+                "_pg_lsn": {"data_type": "bigint", "name": "_pg_lsn", "nullable": True},
+            },
+        },
+        SchemaChoice.error,
+    ),
+    (
+        {
+            "name": "scale_teams",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "nullable": False,
+                    "data_type": "bigint",
+                    "precision": 32,
+                },
+                "user_id": {
+                    "name": "user_id",
+                    "nullable": False,
+                    "data_type": "bigint",
+                    "precision": 32,
+                },
+                "begin_at": {
+                    "name": "begin_at",
+                    "nullable": False,
+                    "data_type": "timestamp",
+                    "precision": 6,
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "nullable": False,
+                    "data_type": "timestamp",
+                    "precision": 6,
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "nullable": False,
+                    "data_type": "timestamp",
+                    "precision": 6,
+                },
+                "scale_id": {
+                    "name": "scale_id",
+                    "nullable": False,
+                    "data_type": "bigint",
+                    "precision": 32,
+                },
+                "team_id": {
+                    "name": "team_id",
+                    "nullable": False,
+                    "data_type": "bigint",
+                    "precision": 32,
+                },
+                "comment": {"name": "comment", "nullable": True, "data_type": "text"},
+                "old_feedback": {
+                    "name": "old_feedback",
+                    "nullable": True,
+                    "data_type": "text",
+                },
+                "feedback_rating": {
+                    "name": "feedback_rating",
+                    "nullable": True,
+                    "data_type": "bigint",
+                    "precision": 32,
+                },
+                "final_mark": {
+                    "name": "final_mark",
+                    "nullable": True,
+                    "data_type": "bigint",
+                    "precision": 32,
+                },
+                "truant_id": {
+                    "name": "truant_id",
+                    "nullable": True,
+                    "data_type": "bigint",
+                    "precision": 32,
+                },
+                "flag_id": {
+                    "name": "flag_id",
+                    "nullable": False,
+                    "data_type": "bigint",
+                    "precision": 32,
+                },
+                "token": {"name": "token", "nullable": True, "data_type": "text"},
+                "ip": {"name": "ip", "nullable": True, "data_type": "text"},
+                "internship_id": {
+                    "name": "internship_id",
+                    "nullable": True,
+                    "data_type": "bigint",
+                    "precision": 32,
+                },
+                "filled_at": {
+                    "name": "filled_at",
+                    "nullable": True,
+                    "data_type": "timestamp",
+                    "precision": 6,
+                },
+                "_pg_lsn": {"name": "_pg_lsn", "nullable": True, "data_type": "bigint"},
+                "_pg_deleted_ts": {
+                    "name": "_pg_deleted_ts",
+                    "nullable": True,
+                    "data_type": "timestamp",
+                    "precision": 6,
+                },
+                "_pg_commit_ts": {
+                    "name": "_pg_commit_ts",
+                    "nullable": True,
+                    "data_type": "timestamp",
+                    "precision": 6,
+                },
+                "_pg_tx_id": {
+                    "name": "_pg_tx_id",
+                    "nullable": True,
+                    "data_type": "bigint",
+                    "precision": 32,
+                },
+                "_dlt_load_id": {
+                    "name": "_dlt_load_id",
+                    "data_type": "text",
+                    "nullable": False,
+                },
+            },
+        },
+        {
+            "name": "scale_teams",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "nullable": False,
+                    "data_type": "bigint",
+                    "precision": 32,
+                },
+                "user_id": {
+                    "name": "user_id",
+                    "nullable": True,
+                    "data_type": "bigint",
+                    "precision": 32,
+                },
+                "begin_at": {
+                    "name": "begin_at",
+                    "nullable": True,
+                    "data_type": "timestamp",
+                    "precision": 6,
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "nullable": False,
+                    "data_type": "timestamp",
+                    "precision": 6,
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "nullable": False,
+                    "data_type": "timestamp",
+                    "precision": 6,
+                },
+                "scale_id": {
+                    "name": "scale_id",
+                    "nullable": True,
+                    "data_type": "bigint",
+                    "precision": 32,
+                },
+                "team_id": {
+                    "name": "team_id",
+                    "nullable": True,
+                    "data_type": "bigint",
+                    "precision": 32,
+                },
+                "comment": {"name": "comment", "nullable": True, "data_type": "text"},
+                "old_feedback": {
+                    "name": "old_feedback",
+                    "nullable": True,
+                    "data_type": "text",
+                },
+                "feedback_rating": {
+                    "name": "feedback_rating",
+                    "nullable": True,
+                    "data_type": "bigint",
+                    "precision": 32,
+                },
+                "final_mark": {
+                    "name": "final_mark",
+                    "nullable": True,
+                    "data_type": "bigint",
+                    "precision": 32,
+                },
+                "truant_id": {
+                    "name": "truant_id",
+                    "nullable": True,
+                    "data_type": "bigint",
+                    "precision": 32,
+                },
+                "flag_id": {
+                    "name": "flag_id",
+                    "nullable": True,
+                    "data_type": "bigint",
+                    "precision": 32,
+                },
+                "token": {"name": "token", "nullable": True, "data_type": "text"},
+                "ip": {"name": "ip", "nullable": True, "data_type": "text"},
+                "internship_id": {
+                    "name": "internship_id",
+                    "nullable": True,
+                    "data_type": "bigint",
+                    "precision": 32,
+                },
+                "filled_at": {
+                    "name": "filled_at",
+                    "nullable": True,
+                    "data_type": "timestamp",
+                    "precision": 6,
+                },
+                "_pg_lsn": {"name": "_pg_lsn", "nullable": True, "data_type": "bigint"},
+                "_pg_deleted_ts": {
+                    "name": "_pg_deleted_ts",
+                    "nullable": True,
+                    "data_type": "timestamp",
+                    "precision": 6,
+                },
+                "_pg_commit_ts": {
+                    "name": "_pg_commit_ts",
+                    "nullable": True,
+                    "data_type": "timestamp",
+                    "precision": 6,
+                },
+                "_pg_tx_id": {
+                    "name": "_pg_tx_id",
+                    "nullable": True,
+                    "data_type": "bigint",
+                    "precision": 32,
+                },
+                "_dlt_load_id": {
+                    "name": "_dlt_load_id",
+                    "data_type": "text",
+                    "nullable": False,
+                },
+            },
+        },
+        SchemaChoice.second,
+    ),
 ]

--- a/tests/pg_legacy_replication/test_helpers.py
+++ b/tests/pg_legacy_replication/test_helpers.py
@@ -2,17 +2,19 @@ import pytest
 from dlt.common.schema.typing import TTableSchema
 from dlt.common.typing import TDataItem
 from google.protobuf.json_format import ParseDict as parse_dict
-
 from sources.pg_legacy_replication.helpers import (
-    infer_table_schema,
-    gen_data_item,
     compare_schemas,
+    gen_data_item,
+    infer_table_schema,
 )
 from sources.pg_legacy_replication.pg_logicaldec_pb2 import RowMessage
-from .cases import ROW_MESSAGES, DATA_ITEMS, TABLE_SCHEMAS
+
+from . import cases
 
 
-@pytest.mark.parametrize("data, expected_schema", zip(ROW_MESSAGES, TABLE_SCHEMAS))
+@pytest.mark.parametrize(
+    "data, expected_schema", zip(cases.ROW_MESSAGES, cases.TABLE_SCHEMAS)
+)
 def test_infer_table_schema(
     data,
     expected_schema: TTableSchema,
@@ -29,7 +31,7 @@ def test_infer_table_schema(
     )
 
 
-@pytest.mark.parametrize("data, data_item", zip(ROW_MESSAGES, DATA_ITEMS))
+@pytest.mark.parametrize("data, data_item", zip(cases.ROW_MESSAGES, cases.DATA_ITEMS))
 def test_gen_data_item(data, data_item: TDataItem):
     row_msg = RowMessage()
     parse_dict(data, row_msg)
@@ -46,204 +48,16 @@ def test_gen_data_item(data, data_item: TDataItem):
     )
 
 
-def test_compare_schemas():
-    s1: TTableSchema = {
-        "name": "items",
-        "columns": {
-            "col1": {
-                "name": "col1",
-                "data_type": "bigint",
-                "precision": 64,
-                "nullable": False,
-            },
-            "col2": {"name": "col2", "data_type": "double", "nullable": False},
-            "col3": {"name": "col3", "data_type": "bool", "nullable": False},
-            "col4": {"name": "col4", "data_type": "timestamp", "nullable": False},
-            "col5": {"name": "col5", "data_type": "text", "nullable": False},
-            "col6": {
-                "name": "col6",
-                "data_type": "decimal",
-                "precision": 38,
-                "scale": 9,
-                "nullable": False,
-            },
-            "col7": {"name": "col7", "data_type": "binary", "nullable": False},
-            "col9": {"name": "col9", "data_type": "json", "nullable": False},
-            "col10": {"name": "col10", "data_type": "date", "nullable": False},
-            "col11": {"name": "col11", "data_type": "time", "nullable": False},
-            "col1_null": {
-                "name": "col1_null",
-                "data_type": "bigint",
-                "precision": 64,
-                "nullable": True,
-            },
-            "col2_null": {"name": "col2_null", "data_type": "double", "nullable": True},
-            "col3_null": {"name": "col3_null", "data_type": "bool", "nullable": True},
-            "col4_null": {
-                "name": "col4_null",
-                "data_type": "timestamp",
-                "nullable": True,
-            },
-            "col5_null": {"name": "col5_null", "data_type": "text", "nullable": True},
-            "col6_null": {
-                "name": "col6_null",
-                "data_type": "decimal",
-                "precision": 38,
-                "scale": 9,
-                "nullable": True,
-            },
-            "col7_null": {"name": "col7_null", "data_type": "binary", "nullable": True},
-            "col9_null": {
-                "name": "col9_null",
-                "data_type": "json",
-                "nullable": True,
-            },
-            "col10_null": {"name": "col10_null", "data_type": "date", "nullable": True},
-            "col11_null": {"name": "col11_null", "data_type": "time", "nullable": True},
-            "col1_precision": {
-                "name": "col1_precision",
-                "data_type": "bigint",
-                "precision": 16,
-                "nullable": False,
-            },
-            "col4_precision": {
-                "name": "col4_precision",
-                "data_type": "timestamp",
-                "precision": 3,
-                "nullable": False,
-            },
-            "col5_precision": {
-                "name": "col5_precision",
-                "data_type": "text",
-                "precision": 25,
-                "nullable": False,
-            },
-            "col6_precision": {
-                "name": "col6_precision",
-                "data_type": "decimal",
-                "precision": 6,
-                "scale": 2,
-                "nullable": False,
-            },
-            "col7_precision": {
-                "name": "col7_precision",
-                "data_type": "binary",
-                "nullable": False,
-            },
-            "col11_precision": {
-                "name": "col11_precision",
-                "data_type": "time",
-                "precision": 3,
-                "nullable": False,
-            },
-            "_dlt_load_id": {
-                "name": "_dlt_load_id",
-                "data_type": "text",
-                "nullable": False,
-            },
-            "_dlt_id": {"name": "_dlt_id", "data_type": "text", "nullable": False},
-            "_pg_lsn": {"data_type": "bigint", "name": "_pg_lsn", "nullable": True},
-            "_pg_deleted_ts": {
-                "data_type": "timestamp",
-                "name": "_pg_deleted_ts",
-                "nullable": True,
-            },
-        },
-    }
-    s2: TTableSchema = {
-        "name": "items",
-        "columns": {
-            "col1": {
-                "name": "col1",
-                "data_type": "bigint",
-                "precision": 64,
-                "nullable": False,
-            },
-            "col2": {"name": "col2", "data_type": "double"},
-            "col3": {"name": "col3", "data_type": "bool"},
-            "col4": {"name": "col4", "data_type": "timestamp"},
-            "col5": {"name": "col5", "data_type": "text"},
-            "col6": {"name": "col6", "data_type": "decimal"},
-            "col7": {"name": "col7", "data_type": "binary"},
-            "col9": {"name": "col9", "data_type": "json"},
-            "col10": {"name": "col10", "data_type": "date"},
-            "col11": {"name": "col11", "data_type": "time"},
-            "col1_null": {"name": "col1_null", "data_type": "bigint", "precision": 64},
-            "col2_null": {"name": "col2_null", "data_type": "double"},
-            "col3_null": {"name": "col3_null", "data_type": "bool"},
-            "col4_null": {"name": "col4_null", "data_type": "timestamp"},
-            "col5_null": {"name": "col5_null", "data_type": "text"},
-            "col6_null": {"name": "col6_null", "data_type": "decimal"},
-            "col7_null": {"name": "col7_null", "data_type": "binary"},
-            "col9_null": {"name": "col9_null", "data_type": "json"},
-            "col10_null": {"name": "col10_null", "data_type": "date"},
-            "col11_null": {"name": "col11_null", "data_type": "time"},
-            "col1_precision": {
-                "name": "col1_precision",
-                "data_type": "bigint",
-                "precision": 16,
-            },
-            "col4_precision": {"name": "col4_precision", "data_type": "timestamp"},
-            "col5_precision": {"name": "col5_precision", "data_type": "text"},
-            "col6_precision": {"name": "col6_precision", "data_type": "decimal"},
-            "col7_precision": {"name": "col7_precision", "data_type": "binary"},
-            "col11_precision": {"name": "col11_precision", "data_type": "time"},
-            "_dlt_load_id": {"name": "_dlt_load_id", "data_type": "text"},
-            "_dlt_id": {"name": "_dlt_id", "data_type": "text"},
-            "_pg_lsn": {"data_type": "bigint", "name": "_pg_lsn", "nullable": True},
-            "_pg_deleted_ts": {
-                "data_type": "timestamp",
-                "name": "_pg_deleted_ts",
-                "nullable": True,
-            },
-        },
-    }
-    assert compare_schemas(s1, s2) == s1
-    assert compare_schemas(s2, s1) == s1
-
-    s1 = {
-        "columns": {
-            "_dlt_id": {"data_type": "text", "name": "_dlt_id", "nullable": False},
-            "_dlt_load_id": {
-                "data_type": "text",
-                "name": "_dlt_load_id",
-                "nullable": False,
-            },
-            "c1": {
-                "data_type": "bigint",
-                "name": "c1",
-                "nullable": True,
-                "precision": 64,
-            },
-            "c2": {
-                "data_type": "bigint",
-                "name": "c2",
-                "nullable": True,
-                "precision": 64,
-            },
-            "c3": {
-                "data_type": "bigint",
-                "name": "c3",
-                "nullable": True,
-                "precision": 64,
-            },
-            "_pg_deleted_ts": {
-                "data_type": "timestamp",
-                "name": "_pg_deleted_ts",
-                "nullable": True,
-            },
-            "_pg_lsn": {"data_type": "bigint", "name": "_pg_lsn", "nullable": True},
-        },
-        "name": "items",
-    }
-    from copy import deepcopy
-
-    s2 = deepcopy(s1)
-    s2["columns"]["c4"] = {
-        "data_type": "bigint",
-        "name": "c4",
-        "nullable": True,
-        "precision": 64,
-    }
-    with pytest.raises(AssertionError):
-        compare_schemas(s1, s2)
+@pytest.mark.parametrize("s1, s2, choice", cases.SIMILAR_SCHEMAS)
+def test_compare_schemas(
+    s1: TTableSchema, s2: TTableSchema, choice: cases.SchemaChoice
+):
+    if choice == cases.SchemaChoice.error:
+        with pytest.raises(AssertionError):
+            compare_schemas(s1, s2)
+        with pytest.raises(AssertionError):
+            compare_schemas(s2, s1)
+    else:
+        expected_schema = (s1, s2)[choice]
+        assert compare_schemas(s1, s2) == expected_schema
+        assert compare_schemas(s2, s1) == expected_schema


### PR DESCRIPTION
This is an attempt at correcting the behavior encountered in https://github.com/dlt-hub/dlt/issues/2229